### PR TITLE
feat: add cypress-utils to tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ Official references of Cypress.
 - [Cypress Commands](https://github.com/Lakitna/cypress-commands) - A collection of Cypress commands to extend and complement the defaults;
 - [Cypress Essencial Minmap](https://github.com/samlucax/cypress-essencial-mindmap) - An open-source mindmap with essentials tools - [Samuel Lucas](https://github.com/samlucax);
 - [Cypress Parallel Specs Locally](https://github.com/Shelex/cypress-parallel-specs-locally) - About
+- [Cypress Utils](https://github.com/trentrand/cypress-utils) - CLI tool to easily parallelize and stress-test your Cypress tests
 - [Cypress Wait Until](https://github.com/NoriSte/cypress-wait-until) - Adds waiting power to virtually everything. Use this plugin to wait for everything not expected by [Cypress wait](https://docs.cypress.io/api/commands/wait.html#Syntax) - [Stefano Magni](https://github.com/NoriSte).
 - [Moon](https://aerokube.com/moon/) - Platform for remote parallel Cypress tests execution working in Kubernetes cluster.
 - [Sorry Cypress](https://github.com/agoldis/sorry-cypress/) - An open-source alternative to cypress dashboard - [Andrew Goldis](https://github.com/agoldis);


### PR DESCRIPTION
This proposed change adds the `cypress-utils` package, which provides a command-line tool to easily parallelize and stress-test your Cypress tests locally.

### Run tests in parallel

To speed up day-to-day local Cypress test runs (e.g. before committing changes to a branch), multiple Cypress test runners can be ran in parallel.

The impact on system resources is surprisingly manageable, even with multiple concurrent runners.

> The total elapsed time was reduced by 38% when running a set of 12 tests in two concurrent threads

To run the entire suite in parallel, exclude any additional command-line arguments:

  ```shell
    cypress-utils run-parallel
  ```

To run two or more test files in parallel, simply specify the files to run:

  ```shell
    cypress-utils run-parallel specFileA specfileB
  ```

#### Example of running tests in parallel:

![run-parallel-example](https://user-images.githubusercontent.com/6083067/125678098-dfe24c25-a9de-43b9-973a-ddc96af410cd.gif)

### Stress test

To ensure your Cypress tests are not irregularly failing with false-negatives, stress testing new test files can be a reliable way of filtering out bad test code.

To stress test one or more test files, simply specify the files to run:

  ```shell
    cypress-utils stress-test specFileA specfileB
  ```

Additional command-line options may be specified, such as the sample size or number of concurrent threads:
  ```shell
   cypress-utils stress-test --trialCount 12 --threads 4
  ```

#### Example of stress testing:
![stress-test-example](https://user-images.githubusercontent.com/6083067/125678347-f48130f8-e451-4dc2-8c1b-db2a59cd4e72.gif)