### PR TITLE
Add Specut

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ Official references of Cypress.
 - [Moon](https://aerokube.com/moon/) - Platform for remote parallel Cypress tests execution working in Kubernetes cluster.
 - [Sorry Cypress](https://github.com/agoldis/sorry-cypress/) - An open-source alternative to cypress dashboard - [Andrew Goldis](https://github.com/agoldis);
 Script for parallel Cypress specs execution locally - [Shelex Oleksandr Shevtsov](https://github.com/Shelex/)
+- [Specut](https://github.com/henryruhs/specut) - Cut massive test suites into equal chunks.
 
 ### Courses
 


### PR DESCRIPTION
Specut let's you cut massive testing suites by it's files or the amount of `it()` and `describe()` blocks. 

![Specut on GitLab Runner](https://user-images.githubusercontent.com/1835397/212441863-8ad9fd67-bd44-44fe-a6d4-c2026ca7a706.png)

This equal chunks allow you to fire parallel CI stages - in this case I used GitLab's Parallel Matrix Builds.

![Specut meets Gitlab Matrix](https://user-images.githubusercontent.com/1835397/212441405-35de0ab2-5d9d-4476-8b2e-1ab1039c7143.png)

It scales pretty well - I could reduce our pipeline from 45min to 15 - 20 mins. Enjoy