### PR TITLE
Add Testward to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ Official references of Cypress.
 - [Sorry Cypress](https://github.com/agoldis/sorry-cypress/) - An open-source alternative to cypress dashboard - [Andrew Goldis](https://github.com/agoldis);
   Script for parallel Cypress specs execution locally - [Shelex Oleksandr Shevtsov](https://github.com/Shelex/)
 - [Specut](https://github.com/henryruhs/specut) - Cut massive test suites into equal chunks.
+- [Testward](https://testward.app) - GitHub App that flags which Cypress specs a pull request will break — at review time, even when the specs live in a separate repo.
 
 ### Courses
 


### PR DESCRIPTION
Adding [Testward](https://testward.app) — a GitHub App that reads each pull request in an app repo and flags which Cypress specs the change will break, at review time. It extracts the anchors the diff touches (data-cy/data-testid attributes, ids, routes, labels) and matches them against spec files, including when the Cypress suite lives in a separate repo linked with a one-line config.

Disclosure: I'm the author. Free on public repos. A no-install client-side demo of the diff analysis is at https://testward.app/diff-scanner.